### PR TITLE
Allow custom panels to use the same animation as non-custom cells

### DIFF
--- a/MYBlurIntroductionView/MYBlurIntroductionView.m
+++ b/MYBlurIntroductionView/MYBlurIntroductionView.m
@@ -291,7 +291,7 @@
         panelView.PanelImageView.alpha = 0;
     }
     
-    if ([Panels[index] isCustomPanel]) {
+    if ([Panels[index] isCustomPanel] && ![Panels[index] hasCustomAnimation]) {
         return;
     }
     

--- a/MYBlurIntroductionView/MYIntroductionPanel.h
+++ b/MYBlurIntroductionView/MYIntroductionPanel.h
@@ -34,6 +34,7 @@ static UIColor *kSeparatorLineColor = nil;
 @property (nonatomic, retain) UIView *PanelSeparatorLine;
 @property (nonatomic, retain) UIImageView *PanelImageView;
 @property (nonatomic, assign) BOOL isCustomPanel;
+@property (nonatomic, assign) BOOL hasCustomAnimation;
 
 //Init Methods
 -(id)initWithFrame:(CGRect)frame title:(NSString *)title description:(NSString *)description;
@@ -48,4 +49,6 @@ static UIColor *kSeparatorLineColor = nil;
 //Interaction Methods
 -(void)panelDidAppear;
 -(void)panelDidDisappear;
+
+-(void)buildPanelWithFrame:(CGRect)frame;
 @end

--- a/MYBlurIntroductionView/MYIntroductionPanel.m
+++ b/MYBlurIntroductionView/MYIntroductionPanel.m
@@ -82,6 +82,7 @@
         self = [[NSBundle mainBundle] loadNibNamed:nibName owner:nil options:nil][0];
         self.frame = frame;
         self.isCustomPanel = YES;
+        self.hasCustomAnimation = NO;
     }
     return self;
 }
@@ -172,6 +173,11 @@
         self.PanelImageView.contentMode = UIViewContentModeCenter;
         self.PanelImageView.clipsToBounds = YES;
         [self addSubview:self.PanelImageView];
+    }
+
+    // If this is a custom panel, set the has Custom animation boolean
+    if (self.isCustomPanel == YES) {
+        self.hasCustomAnimation = YES;
     }
 }
 


### PR DESCRIPTION
Allows for custom panels to have the same animation as non-custom panels.  After setting the particular attributes you want to animate you call buildPanelWithFrame and send it the panel frame to setup the animation.

If you do not call buildPanelWithFrame, it will act as it did before.

Example

```
    //Create Panel From Nib
    MYIntroductionPanel *panel4 = [[MYIntroductionPanel alloc] initWithFrame:CGRectMake(0, 0, self.view.frame.size.width, self.view.frame.size.height) nibNamed:@"EmailView"];
    [panel4 setBackgroundColor:[UIColor colorWithRed:0.876 green:0.864 blue:0.214 alpha:0.100]];
    [panel4 setPanelTitle:@"Test Title"];
    panel4.PanelTitle = @"Test Title";
    panel4.PanelDescription = @"Test Description";
    [panel4 buildPanelWithFrame:panel4.frame];
```
