### PR TITLE
Support changing to a specific panel

### DIFF
--- a/MYBlurIntroductionView/MYBlurIntroductionView.h
+++ b/MYBlurIntroductionView/MYBlurIntroductionView.h
@@ -70,6 +70,8 @@ typedef enum {
 
 //Interaction Methods
 - (IBAction)didPressSkipButton;
+
+// index is relative to the array of panels passed in.
 -(void)changeToPanelAtIndex:(NSInteger)index;
 
 //Enables or disables use of the introductionView. Use this if you want to hold someone on a panel until they have completed some task

--- a/MYBlurIntroductionView/MYBlurIntroductionView.m
+++ b/MYBlurIntroductionView/MYBlurIntroductionView.m
@@ -361,7 +361,34 @@
 }
 
 -(void)changeToPanelAtIndex:(NSInteger)index{
+    int currentIndex = self.CurrentPanelIndex;
+    if (self.LanguageDirection == MYLanguageDirectionRightToLeft)
+        currentIndex = (Panels.count-1)-self.CurrentPanelIndex;
     
+    if (Panels && index < Panels.count && currentIndex != index)
+    {
+        // For right-to-left, PageControl index is the inverse of the panel indicies.
+        
+        if ([Panels[currentIndex] respondsToSelector:@selector(panelDidDisappear)]) {
+            [Panels[currentIndex] panelDidDisappear];
+        }
+        
+        CGRect panelRect = [Panels[index] frame];
+        [self.MasterScrollView scrollRectToVisible:panelRect animated:YES];
+        self.CurrentPanelIndex = index;
+        [self animatePanelAtIndex:index];
+        
+        if (self.LanguageDirection == MYLanguageDirectionLeftToRight)
+            self.PageControl.currentPage = index;
+        else if (self.LanguageDirection == MYLanguageDirectionRightToLeft)
+            self.PageControl.currentPage = (Panels.count-1)-index;
+        
+        
+        if ([Panels[index] respondsToSelector:@selector(panelDidAppear)]) {
+            [Panels[index] panelDidAppear];
+        }
+    }
+    // Not sure what to do in the case when an out-of-index panel is specified... exception? nothing?
 }
 
 -(void)setEnabled:(BOOL)enabled{


### PR DESCRIPTION
Implemented -[MYBlurIntroductionView changeToPanelAtIndex:].
Supports both text directions, as far as I'm able to test.
Unclear whether the original intention of the function was to take the
absolute index of the panel to display or the index relative to the
text direction.
