### PR TITLE
Adding more skip button options

### DIFF
--- a/MYBlurIntroductionView/MYBlurIntroductionView.h
+++ b/MYBlurIntroductionView/MYBlurIntroductionView.h
@@ -33,6 +33,15 @@ typedef enum {
     MYRightButton
 }MYButtonType;
 
+//Enum to decide to show both buttons or standard behavior
+typedef enum {
+    MYStandardBehavior = 0,
+    MYShowLeftButton,
+    MYShowRightButton,
+    MYShowBothButtons
+    
+}MYButtonBehaviorType;
+
 @class MYBlurIntroductionView;
 
 /******************************/
@@ -71,7 +80,7 @@ typedef enum {
 @property (nonatomic, assign) NSInteger CurrentPanelIndex;
 @property (nonatomic, assign) MYLanguageDirection LanguageDirection;
 @property (nonatomic, retain) UIColor *UserBackgroundColor;
-@property (nonatomic, assign) BOOL allowCustomSkipButtonActions;
+@property (nonatomic, assign) MYButtonBehaviorType ButtonBehavior;
 
 //Construction Methods
 -(void)buildIntroductionWithPanels:(NSArray *)panels;

--- a/MYBlurIntroductionView/MYBlurIntroductionView.h
+++ b/MYBlurIntroductionView/MYBlurIntroductionView.h
@@ -27,6 +27,12 @@ typedef enum {
     MYLanguageDirectionRightToLeft
 }MYLanguageDirection;
 
+//Enum to determine which button was pressed
+typedef enum {
+    MYLeftButton = 0,
+    MYRightButton
+}MYButtonType;
+
 @class MYBlurIntroductionView;
 
 /******************************/
@@ -34,6 +40,7 @@ typedef enum {
 /******************************/
 @protocol MYIntroductionDelegate
 @optional
+-(void)introduction:(MYBlurIntroductionView *)introductionView didPressButton:(MYButtonType)buttonType;
 -(void)introduction:(MYBlurIntroductionView *)introductionView didFinishWithType:(MYFinishType)finishType;
 -(void)introduction:(MYBlurIntroductionView *)introductionView didChangeToPanel:(MYIntroductionPanel *)panel withIndex:(NSInteger)panelIndex;
 @end
@@ -64,12 +71,13 @@ typedef enum {
 @property (nonatomic, assign) NSInteger CurrentPanelIndex;
 @property (nonatomic, assign) MYLanguageDirection LanguageDirection;
 @property (nonatomic, retain) UIColor *UserBackgroundColor;
+@property (nonatomic, assign) BOOL allowCustomSkipButtonActions;
 
 //Construction Methods
 -(void)buildIntroductionWithPanels:(NSArray *)panels;
 
 //Interaction Methods
-- (IBAction)didPressSkipButton;
+- (IBAction)didPressSkipButton:(id)sender;
 
 // index is relative to the array of panels passed in.
 -(void)changeToPanelAtIndex:(NSInteger)index;

--- a/MYBlurIntroductionView/MYBlurIntroductionView.m
+++ b/MYBlurIntroductionView/MYBlurIntroductionView.m
@@ -22,6 +22,9 @@
 }
 
 -(void)initializeViewComponents{
+    //Custom skip buttons
+    self.allowCustomSkipButtonActions = NO;
+    
     //Background Image View
     self.BackgroundImageView = [[UIImageView alloc] initWithFrame:self.frame];
     self.BackgroundImageView.contentMode = UIViewContentModeScaleAspectFill;
@@ -62,7 +65,7 @@
     self.LeftSkipButton.frame = CGRectMake(10, self.frame.size.height - 48, 46, 37);
     [self.LeftSkipButton setTitle:skipString forState:UIControlStateNormal];
     [self.LeftSkipButton.titleLabel setFont:kSkipButtonFont];
-    [self.LeftSkipButton addTarget:self action:@selector(didPressSkipButton) forControlEvents:UIControlEventTouchUpInside];
+    [self.LeftSkipButton addTarget:self action:@selector(didPressSkipButton:) forControlEvents:UIControlEventTouchUpInside];
     [self addSubview:self.LeftSkipButton];
     
     //Right Skip Button
@@ -70,7 +73,7 @@
     self.RightSkipButton.frame = CGRectMake(self.frame.size.width - skipStringWidth - kLeftRightSkipPadding, self.frame.size.height - 48, skipStringWidth, 37);
     [self.RightSkipButton.titleLabel setFont:kSkipButtonFont];
     [self.RightSkipButton setTitle:skipString forState:UIControlStateNormal];
-    [self.RightSkipButton addTarget:self action:@selector(didPressSkipButton) forControlEvents:UIControlEventTouchUpInside];
+    [self.RightSkipButton addTarget:self action:@selector(didPressSkipButton:) forControlEvents:UIControlEventTouchUpInside];
     [self addSubview:self.RightSkipButton];
 }
 
@@ -341,8 +344,21 @@
 
 #pragma mark - Interaction Methods
 
-- (void)didPressSkipButton {
-    [self skipIntroduction];
+- (void)didPressSkipButton:(id)sender {
+    if(!_allowCustomSkipButtonActions) {
+        [self skipIntroduction];
+        return;
+    }
+    
+    if(sender == self.LeftSkipButton) {
+        if ([(id)delegate respondsToSelector:@selector(introduction:didPressButton:)]) {
+            [delegate introduction:self didPressButton:MYLeftButton];
+        }
+    } else if(sender == self.RightSkipButton) {
+        if ([(id)delegate respondsToSelector:@selector(introduction:didPressButton:)]) {
+            [delegate introduction:self didPressButton:MYRightButton];
+        }
+    }
 }
 
 -(void)skipIntroduction{

--- a/MYBlurIntroductionView/MYBlurIntroductionView.m
+++ b/MYBlurIntroductionView/MYBlurIntroductionView.m
@@ -23,7 +23,7 @@
 
 -(void)initializeViewComponents{
     //Custom skip buttons
-    self.allowCustomSkipButtonActions = NO;
+    [self setButtonBehavior:MYStandardBehavior];
     
     //Background Image View
     self.BackgroundImageView = [[UIImageView alloc] initWithFrame:self.frame];
@@ -174,13 +174,13 @@
 }
 
 /*
-// Only override drawRect: if you perform custom drawing.
-// An empty implementation adversely affects performance during animation.
-- (void)drawRect:(CGRect)rect
-{
-    // Drawing code
-}
-*/
+ // Only override drawRect: if you perform custom drawing.
+ // An empty implementation adversely affects performance during animation.
+ - (void)drawRect:(CGRect)rect
+ {
+ // Drawing code
+ }
+ */
 
 #pragma mark - UIScrollView Delegate
 
@@ -345,7 +345,7 @@
 #pragma mark - Interaction Methods
 
 - (void)didPressSkipButton:(id)sender {
-    if(!_allowCustomSkipButtonActions) {
+    if(self.ButtonBehavior == MYStandardBehavior) {
         [self skipIntroduction];
         return;
     }
@@ -415,7 +415,7 @@
 
 -(void)setEnabled:(BOOL)enabled{
     [UIView animateWithDuration:0.3 animations:^{
-        if (enabled) {
+        if (enabled && self.ButtonBehavior == MYStandardBehavior) {
             if (self.LanguageDirection == MYLanguageDirectionLeftToRight) {
                 self.LeftSkipButton.alpha = !enabled;
                 self.RightSkipButton.alpha = enabled;
@@ -425,6 +425,11 @@
                 self.RightSkipButton.alpha = !enabled;
             }
             
+            self.MasterScrollView.scrollEnabled = YES;
+        }
+        else if (enabled && self.ButtonBehavior != MYStandardBehavior) {
+            self.LeftSkipButton.alpha = enabled;
+            self.RightSkipButton.alpha = enabled;
             self.MasterScrollView.scrollEnabled = YES;
         }
         else {


### PR DESCRIPTION
I found for my use case I needed a way to make the buttons in the bottom left and right be a back or next or finish button.  I added an enum type that allows the developer to specify if they want to show both buttons, 1 button or use it the way it was originally intended. Eventually I am sure we could modify this more to include each type of workflow a dev would need.

I  also purposely did not rename the buttons from SkipButton to keep compatibility that other people may have. I also made the original workflow the standard one.
