### PR TITLE
Adjusted for cases where intro's frame is not fullscreen

### DIFF
--- a/MYBlurIntroductionView/MYBlurIntroductionView.m
+++ b/MYBlurIntroductionView/MYBlurIntroductionView.m
@@ -35,6 +35,7 @@
     self.BackgroundImageView = [[UIImageView alloc] initWithFrame:self.frame];
     self.BackgroundImageView.contentMode = UIViewContentModeScaleAspectFill;
     self.BackgroundImageView.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleHeight;
+    self.BackgroundImageView.clipsToBounds = YES;
     [self addSubview:self.BackgroundImageView];
     
     //Master Scroll View


### PR DESCRIPTION
-As it was before, if we set-up an MYBlurIntroductionView with a frame that was smaller then the screen size, then the background image set for the BlurIntroView would show outside the defined bounds. By setting clipsToBounds property, we can now avoid this issue.
